### PR TITLE
add a 2nd bound property so we can build DOM attribute correctly. 

### DIFF
--- a/ember-contenteditable-view.js
+++ b/ember-contenteditable-view.js
@@ -1,46 +1,51 @@
 App.ContenteditableView = Em.View.extend({
-	tagName: 'div',
-	attributeBindings: ['contenteditable'],
-	
-	// Toggle plain text inside the <div> element:
-	plaintext: false,
+  tagName: "div",
 
-	// Variables:
-	contenteditable: 'true',
-	isUserTyping: false,
+  attributeBindings: ['contenteditable'],
 
-	// Observers:
-	valueObserver: (function() {
-		if (!this.get('isUserTyping') && this.get('value')) {
-			this.setContent();
-		}
-	}).observes('value'),
+  plaintext: false,
 
-	// Events:
-	didInsertElement: function() {
-		this.setContent();
-	},
+  isUserTyping: false,
 
-	focusOut: function() {
-		this.set('isUserTyping', false);
-	},
+  editable: false,
 
-	keyDown: function(event) {
-		if (!event.metaKey) {
-			this.set('isUserTyping', true);
-		}
-	},
+  contenteditable: (function() {
+    if (this.get('editable')) {
+      return "true";
+    } else {
+      return "false";
+    }
+  }).property('editable'),
 
-	keyUp: function(event) {
-		if (this.get('plaintext')) {
-			this.set('value', this.$().text());
-		} else {
-			this.set('value', this.$().html());
-		}
-	},
-	
-	setContent: function() {
-		this.$().html(this.get('value'));
-	}
+  valueObserver: (function() {
+    if (!this.get("isUserTyping") && this.get("value")) {
+      return this.setContent();
+    }
+  }).observes("value"),
 
+  didInsertElement: function() {
+    return this.setContent();
+  },
+
+  focusOut: function() {
+    return this.set("isUserTyping", false);
+  },
+
+  keyDown: function(event) {
+    if (!event.metaKey) {
+      return this.set("isUserTyping", true);
+    }
+  },
+
+  keyUp: function(event) {
+    if (this.get("plaintext")) {
+      return this.set("value", this.$().text());
+    } else {
+      return this.set("value", this.$().html());
+    }
+  },
+
+  setContent: function() {
+    return this.$().html(this.get("value"));
+  }
 });


### PR DESCRIPTION
Since Ember's default method of creating DOM elements with boolean attributes is to repeat the attribute name as the value, we need a 2nd property to return a strict `true` or `false` for the `contenteditable` binding. 

The syntax for using this in a template now becomes

```
{{view App.ContenteditableView
            valueBinding="description"
            tagName="p"
            editableBinding="somePropertyOnController"}}
}}
```
