### PR TITLE
when the user changes the HTML, the ember metamorphs get wiped out.

### DIFF
--- a/ember-contenteditable-view.js
+++ b/ember-contenteditable-view.js
@@ -44,6 +44,11 @@ Ember.ContenteditableView = Em.View.extend({
 		}
 	},
 
+  //render our own html so there are no metamorphs to get screwed up when the user changes the html
+  render: function(buffer) {
+    buffer.push( this.get('value') )
+  },
+
 	setContent: function() {
 		return this.$().html(this.get('value'));
 	}


### PR DESCRIPTION
I ran into this issue:

https://github.com/emberjs/ember.js/issues/1582

When using a element, ember creates metamorphs to track the changes to the model and update the view. 

However, those metamorphs get removed by the browser when the user updates the HTML via contenteditable .

But since we're updating the view on our own anyway, we don't really need the metamorphs.
By overriding the render method,  we skip the metamoprhs, and they're never missed.
